### PR TITLE
fix(components/input): negative change when using arrow keys

### DIFF
--- a/web/src/components/Appearance/components/Input.tsx
+++ b/web/src/components/Appearance/components/Input.tsx
@@ -122,7 +122,7 @@ const Input: React.FC<InputProps> = ({ title, min = 0, max = 255, blacklisted = 
       if(!isBlacklisted(_value, blacklisted)) {
         return normalize(_value);
       }
-      factor = 1
+      factor = _value > defaultValue ? 1 : -1;
     }
 
     do {


### PR DESCRIPTION
Resolves a bug when changing the input value using arrow keys.
It would get stuck right before the blacklisted value when changing to lower value using down arrow key.